### PR TITLE
manage metro config via versioned package

### DIFF
--- a/.changeset/pre/cuddly-olives-divide.md
+++ b/.changeset/pre/cuddly-olives-divide.md
@@ -1,0 +1,7 @@
+---
+"expo-desktop-metro-config": patch
+"expo-desktop-template-bare-minimum": patch
+"expo-desktop-template-blank-typescript": patch
+---
+
+Use expo-desktop-metro-config instead of unmaintained metro.config.js

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - "packages/*/CHANGELOG.md"
+      - "packages/expo-desktop-metro-config/*/CHANGELOG.md"
       - "templates/*/*/CHANGELOG.md"
   workflow_dispatch:
 
@@ -42,6 +43,7 @@ jobs:
             --frozen-lockfile \
             --filter expo-desktop \
             --filter expo-desktop-config-plugins \
+            --filter expo-desktop-metro-config \
             --filter expo-desktop-modules-core \
             --filter expo-desktop-prebuild-config \
             --filter expo-desktop-stubs \

--- a/packages/expo-desktop-config-plugins/tsconfig.json
+++ b/packages/expo-desktop-config-plugins/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "allowJs": true,
     "types": ["node"],
-    "typeRoots": ["../../node_modules/@types", "typeRoot"],
+    "typeRoots": ["node_modules/@types", "../../node_modules/@types", "typeRoot"],
     "noEmit": false,
     "exactOptionalPropertyTypes": true,
     "declaration": true,

--- a/packages/expo-desktop-metro-config/54.81/.gitignore
+++ b/packages/expo-desktop-metro-config/54.81/.gitignore
@@ -1,0 +1,5 @@
+types
+
+# `pnpm pack` outputs
+expo-desktop-metro-config-*.tgz
+package

--- a/packages/expo-desktop-metro-config/54.81/CHANGELOG.md
+++ b/packages/expo-desktop-metro-config/54.81/CHANGELOG.md
@@ -1,0 +1,7 @@
+# expo-desktop-metro-config
+
+## 54.81.0-beta.2
+
+### Patch Changes
+
+- Use expo-desktop-metro-config instead of unmaintained metro.config.js

--- a/packages/expo-desktop-metro-config/54.81/LICENCE.txt
+++ b/packages/expo-desktop-metro-config/54.81/LICENCE.txt
@@ -1,0 +1,18 @@
+Copyright 2026 Jamie Birch
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the “Software”), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/expo-desktop-metro-config/54.81/package.json
+++ b/packages/expo-desktop-metro-config/54.81/package.json
@@ -33,6 +33,7 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
+    "@expo/metro-config": "catalog:react-native-81",
     "@react-native/metro-config": "catalog:react-native-81",
     "@rnx-kit/metro-config": "^2.2.4"
   }

--- a/packages/expo-desktop-metro-config/54.81/package.json
+++ b/packages/expo-desktop-metro-config/54.81/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "expo-desktop-metro-config",
+  "version": "54.81.0-beta.1",
+  "description": "Desktop-friendly Expo Metro config",
+  "keywords": [
+    "android",
+    "expo",
+    "ios",
+    "macos",
+    "react native",
+    "react native desktop",
+    "windows"
+  ],
+  "homepage": "https://github.com/shirakaba/expo-desktop/tree/main/packages/expo-desktop-metro-config/54.81",
+  "bugs": {
+    "url": "https://github.com/shirakaba/expo-desktop/issues"
+  },
+  "license": "MIT",
+  "author": "Jamie Birch <14055146+shirakaba@users.noreply.github.com> (https://github.com/shirakaba)",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/shirakaba/expo-desktop.git",
+    "directory": "packages/expo-desktop-metro-config/54.81"
+  },
+  "files": [
+    "src"
+  ],
+  "type": "commonjs",
+  "exports": {
+    ".": {
+      "require": "./src/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "dependencies": {
+    "@react-native/metro-config": "catalog:react-native-81",
+    "@rnx-kit/metro-config": "^2.2.4"
+  }
+}

--- a/packages/expo-desktop-metro-config/54.81/package.json
+++ b/packages/expo-desktop-metro-config/54.81/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-desktop-metro-config",
-  "version": "54.81.0-beta.1",
+  "version": "54.81.0-beta.2",
   "description": "Desktop-friendly Expo Metro config",
   "keywords": [
     "android",

--- a/packages/expo-desktop-metro-config/54.81/src/index.js
+++ b/packages/expo-desktop-metro-config/54.81/src/index.js
@@ -1,0 +1,14 @@
+const { getDefaultConfig } = require("@expo/metro-config");
+const { makeMetroConfig: makeRnxKitMetroConfig } = require("@rnx-kit/metro-config");
+
+/**
+ * @param {Parameters<import("@expo/metro-config").getDefaultConfig>} args
+ * @return {ReturnType<import("@rnx-kit/metro-config").makeMetroConfig>}
+ */
+function makeMetroConfig(...args) {
+  const config = makeRnxKitMetroConfig(getDefaultConfig(...args));
+  config.resolver.platforms = ["ios", "android", "macos", "windows", "web"];
+  return config;
+}
+
+module.exports = makeMetroConfig;

--- a/packages/expo-desktop-prebuild-config/tsconfig.json
+++ b/packages/expo-desktop-prebuild-config/tsconfig.json
@@ -4,7 +4,6 @@
     "allowJs": true,
     "types": ["node"],
     "rootDir": "src",
-    "typeRoots": ["../../node_modules/@types"],
     "noEmit": false,
     "exactOptionalPropertyTypes": true,
     "declaration": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ catalogs:
       specifier: ^56.0.15
       version: 56.0.15
   react-native-81:
+    '@expo/metro-config':
+      specifier: ^54.0.17
+      version: 54.0.17
     '@react-native/metro-config':
       specifier: ~0.81.6
       version: 0.81.6
@@ -289,6 +292,9 @@ importers:
 
   packages/expo-desktop-metro-config/54.81:
     dependencies:
+      '@expo/metro-config':
+        specifier: catalog:react-native-81
+        version: 54.0.17(expo@54.0.34(@babel/core@7.29.0(supports-color@8.1.1))(react-native@0.81.6(@babel/core@7.29.0(supports-color@8.1.1))(@react-native-community/cli@20.1.3(supports-color@8.1.1))(@react-native/metro-config@0.81.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.1.17)(react@19.1.4)(supports-color@8.1.1))(react@19.1.4)(supports-color@8.1.1))(supports-color@8.1.1)
       '@react-native/metro-config':
         specifier: catalog:react-native-81
         version: 0.81.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
@@ -1132,6 +1138,9 @@ packages:
   '@expo/config-plugins@54.0.4':
     resolution: {integrity: sha512-g2yXGICdoOw5i3LkQSDxl2Q5AlQCrG7oniu0pCPPO+UxGb7He4AFqSvPSy8HpRUj55io17hT62FTjYRD+d6j3Q==}
 
+  '@expo/config-plugins@54.0.5':
+    resolution: {integrity: sha512-aWQ3sViNRoQWw6So4A2qhWCt24CuGBK6MrRHI1AG+V6/NQAjIZCHaSvcXK2gXKpmisRhTSUWaKPIgLJQFB+AeQ==}
+
   '@expo/config-plugins@56.0.8':
     resolution: {integrity: sha512-phTuyBhgVLfqUHMjQkAfRtbyoY6yTxoKja1awtpVnEkoJDxPJuXx1KX5uvq1eZtt4bJQ08OBJ6P95INqRSHpRg==}
 
@@ -1143,6 +1152,9 @@ packages:
 
   '@expo/config@12.0.13':
     resolution: {integrity: sha512-Cu52arBa4vSaupIWsF0h7F/Cg//N374nYb7HAxV0I4KceKA7x2UXpYaHOL7EEYYvp7tZdThBjvGpVmr8ScIvaQ==}
+
+  '@expo/config@12.0.14':
+    resolution: {integrity: sha512-3dfbBd9LnPDgyylhCgkOsaG8Adg52uOVOTQYH5lf23a/t8M5eQpXKCvzUarrf62B78057n2NnkiofK9TfPgvzw==}
 
   '@expo/config@56.0.9':
     resolution: {integrity: sha512-/lqFeWGSrhpKJVP8tTN8LjuoIe8u8q2w7FzBL0C+wHgl+WM8l1qUIEYWy/sMvsG/NbpUIUsDHJRhQvOkU58eIw==}
@@ -1164,6 +1176,9 @@ packages:
   '@expo/env@2.0.11':
     resolution: {integrity: sha512-xV+ps6YCW7XIPVUwFVCRN2nox09dnRwy8uIjwHWTODu0zFw4kp4omnVkl0OOjuu2XOe7tdgAHxikrkJt9xB/7Q==}
 
+  '@expo/env@2.0.12':
+    resolution: {integrity: sha512-wVfzeBGlUohZG5kS8QCqXurpuWZFJEkBB1wXCifai3EZ/Llcg/VMTiUCpAgHImD3lI7GIU3V1uI64c04XIo98Q==}
+
   '@expo/env@2.3.0':
     resolution: {integrity: sha512-9HnnIbzwTTdbwSjNLXTk0fPm9ZwMJ7c1/31tsni8HZ8Q62KzYCyspahH+V365vg5J6lr001DzNwBxVWSaYCQLg==}
     engines: {node: '>=20.12.0'}
@@ -1181,11 +1196,22 @@ packages:
   '@expo/json-file@10.0.14':
     resolution: {integrity: sha512-yWwBFywFv+SxkJp/pIzzA416JVYflNUh7pqQzgaA6nXDqRyK7KfrqVzk8PdUfDnqbBcaZZxpzNssfQZzp5KHrA==}
 
+  '@expo/json-file@10.0.16':
+    resolution: {integrity: sha512-fcVkWEj+hLuP2yt5W0aw6LmDRqSPWDLUSxOMcmFeV+algmIF59sQVKCwB9btjQLd4V6x9N0pISkQEkBubUHrCw==}
+
   '@expo/json-file@10.2.0':
     resolution: {integrity: sha512-S6XzKe3R9GQeHiUPXc3xJjOv2VJhOEwFYf7xdC2z2cUqt3kZJ9mSO877sNQloVdnW/SUCtPY3bexlM7nwq+CAQ==}
 
   '@expo/metro-config@54.0.15':
     resolution: {integrity: sha512-SqIya4VZ9KHM1S9g+xR0A+QKw1Tfs7Gacx6bQNJ98vs4+O7I5+QP5mHZIB0QSZLUV8opiXebHYTiTu+0OAsIUw==}
+    peerDependencies:
+      expo: '*'
+    peerDependenciesMeta:
+      expo:
+        optional: true
+
+  '@expo/metro-config@54.0.17':
+    resolution: {integrity: sha512-PQFgQCZGY0DffZUvBzJttDPreZfHrQakaBlKjnvOUMNXbDna+TYmg1IFZuIDUYJezLcdp+TvVFTLjNi1+mqaVw==}
     peerDependencies:
       expo: '*'
     peerDependenciesMeta:
@@ -1207,6 +1233,9 @@ packages:
 
   '@expo/plist@0.4.8':
     resolution: {integrity: sha512-pfNtErGGzzRwHP+5+RqswzPDKkZrx+Cli0mzjQaus1ZWFsog5ibL+nVT3NcporW51o8ggnt7x813vtRbPiyOrQ==}
+
+  '@expo/plist@0.4.9':
+    resolution: {integrity: sha512-MPVpmKGfnQEnrCzgxuXcmPP/y/t6AVm+DcSb2Myp21LKWv1N3l8uFxMggesfF4ixAxkRlGmMMx9GyDC9M+XklQ==}
 
   '@expo/plist@0.7.0':
     resolution: {integrity: sha512-vrpryU1GoqSIRNqRB2D3IjXDmzNYfiQpEF6AH/xknlD7eiYmEDt3mb26V7cLcedcPG8PY/1xWHdBXVQJfEAh6Q==}
@@ -5879,6 +5908,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@expo/config-plugins@54.0.5(supports-color@8.1.1)':
+    dependencies:
+      '@expo/config-types': 54.0.10
+      '@expo/json-file': 10.0.16
+      '@expo/plist': 0.4.9
+      '@expo/sdk-runtime-versions': 1.0.0
+      chalk: 4.1.2
+      debug: 4.4.3(supports-color@8.1.1)
+      getenv: 2.0.0
+      glob: 13.0.6
+      resolve-from: 5.0.0
+      semver: 7.8.5
+      slash: 3.0.0
+      slugify: 1.6.9
+      xcode: 3.0.1
+      xml2js: 0.6.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@expo/config-plugins@56.0.8(supports-color@8.1.1)':
     dependencies:
       '@expo/config-types': 56.0.5
@@ -5920,6 +5968,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@expo/config@12.0.14(supports-color@8.1.1)':
+    dependencies:
+      '@babel/code-frame': 7.10.4
+      '@expo/config-plugins': 54.0.5(supports-color@8.1.1)
+      '@expo/config-types': 54.0.10
+      '@expo/json-file': 10.2.0
+      deepmerge: 4.3.1
+      getenv: 2.0.0
+      glob: 13.0.6
+      require-from-string: 2.0.2
+      resolve-from: 5.0.0
+      resolve-workspace-root: 2.0.1
+      semver: 7.8.5
+      slugify: 1.6.9
+      sucrase: 3.35.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@expo/config@56.0.9(supports-color@8.1.1)':
     dependencies:
       '@expo/config-plugins': 56.0.8(supports-color@8.1.1)
@@ -5951,6 +6017,16 @@ snapshots:
       react-native: 0.81.6(@babel/core@7.29.0(supports-color@8.1.1))(@react-native-community/cli@20.1.3(supports-color@8.1.1))(@react-native/metro-config@0.81.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.1.17)(react@19.1.4)(supports-color@8.1.1)
 
   '@expo/env@2.0.11(supports-color@8.1.1)':
+    dependencies:
+      chalk: 4.1.2
+      debug: 4.4.3(supports-color@8.1.1)
+      dotenv: 16.4.7
+      dotenv-expand: 11.0.7
+      getenv: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@expo/env@2.0.12(supports-color@8.1.1)':
     dependencies:
       chalk: 4.1.2
       debug: 4.4.3(supports-color@8.1.1)
@@ -6015,6 +6091,11 @@ snapshots:
       '@babel/code-frame': 7.29.0
       json5: 2.2.3
 
+  '@expo/json-file@10.0.16':
+    dependencies:
+      '@babel/code-frame': 7.10.4
+      json5: 2.2.3
+
   '@expo/json-file@10.2.0':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -6028,6 +6109,36 @@ snapshots:
       '@expo/config': 12.0.13(supports-color@8.1.1)
       '@expo/env': 2.0.11(supports-color@8.1.1)
       '@expo/json-file': 10.0.14
+      '@expo/metro': 54.2.0(supports-color@8.1.1)
+      '@expo/spawn-async': 1.8.0
+      browserslist: 4.28.2
+      chalk: 4.1.2
+      debug: 4.4.3(supports-color@8.1.1)
+      dotenv: 16.4.7
+      dotenv-expand: 11.0.7
+      getenv: 2.0.0
+      glob: 13.0.6
+      hermes-parser: 0.29.1
+      jsc-safe-url: 0.2.4
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.4.49
+      resolve-from: 5.0.0
+    optionalDependencies:
+      expo: 54.0.34(@babel/core@7.29.0(supports-color@8.1.1))(react-native@0.81.6(@babel/core@7.29.0(supports-color@8.1.1))(@react-native-community/cli@20.1.3(supports-color@8.1.1))(@react-native/metro-config@0.81.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.1.17)(react@19.1.4)(supports-color@8.1.1))(react@19.1.4)(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@expo/metro-config@54.0.17(expo@54.0.34(@babel/core@7.29.0(supports-color@8.1.1))(react-native@0.81.6(@babel/core@7.29.0(supports-color@8.1.1))(@react-native-community/cli@20.1.3(supports-color@8.1.1))(@react-native/metro-config@0.81.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.1.17)(react@19.1.4)(supports-color@8.1.1))(react@19.1.4)(supports-color@8.1.1))(supports-color@8.1.1)':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/generator': 7.29.1
+      '@expo/config': 12.0.14(supports-color@8.1.1)
+      '@expo/env': 2.0.12(supports-color@8.1.1)
+      '@expo/json-file': 10.0.16
       '@expo/metro': 54.2.0(supports-color@8.1.1)
       '@expo/spawn-async': 1.8.0
       browserslist: 4.28.2
@@ -6094,6 +6205,12 @@ snapshots:
       resolve-workspace-root: 2.0.1
 
   '@expo/plist@0.4.8':
+    dependencies:
+      '@xmldom/xmldom': 0.8.13
+      base64-js: 1.5.1
+      xmlbuilder: 15.1.1
+
+  '@expo/plist@0.4.9':
     dependencies:
       '@xmldom/xmldom': 0.8.13
       base64-js: 1.5.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,7 +45,7 @@ catalogs:
       version: 56.0.15
   react-native-81:
     '@react-native/metro-config':
-      specifier: ~0.81.0
+      specifier: ~0.81.6
       version: 0.81.6
     '@types/react':
       specifier: ~19.1.0
@@ -286,6 +286,15 @@ importers:
       '@typescript/native-preview':
         specifier: catalog:base
         version: 7.0.0-dev.20260507.1
+
+  packages/expo-desktop-metro-config/54.81:
+    dependencies:
+      '@react-native/metro-config':
+        specifier: catalog:react-native-81
+        version: 0.81.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1)
+      '@rnx-kit/metro-config':
+        specifier: ^2.2.4
+        version: 2.2.4(@react-native/metro-config@0.81.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1))(metro@0.83.7(supports-color@8.1.1))(react-native@0.81.6(@babel/core@7.29.0(supports-color@8.1.1))(@react-native-community/cli@20.1.3(supports-color@8.1.1))(@react-native/metro-config@0.81.6(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.1.17)(react@19.1.4)(supports-color@8.1.1))(react@19.1.4)
 
   packages/expo-desktop-modules-core:
     devDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,6 +20,7 @@ catalogs:
     "@expo/config": ^12.0.13
     "@expo/config-plugins": ^54.0.4
     "@expo/config-types": ^54.0.10
+    "@expo/metro-config": ^54.0.17
     "@expo/prebuild-config": ^54.0.8
     "@react-native/metro-config": ~0.81.6
     "@types/react": ~19.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
   - packages/expo-desktop
   - packages/expo-desktop/scripts
   - packages/expo-desktop-config-plugins
+  - packages/expo-desktop-metro-config/*
   - packages/expo-desktop-modules-core
   - packages/expo-desktop-prebuild-config
   - packages/expo-desktop-stubs
@@ -20,7 +21,7 @@ catalogs:
     "@expo/config-plugins": ^54.0.4
     "@expo/config-types": ^54.0.10
     "@expo/prebuild-config": ^54.0.8
-    "@react-native/metro-config": ~0.81.0
+    "@react-native/metro-config": ~0.81.6
     "@types/react": ~19.1.0
     expo: ^54.0.33
     react: 19.1.4
@@ -32,7 +33,7 @@ catalogs:
     "@expo/config-plugins": ^55.0.8
     "@expo/config-types": ^55.0.5
     "@expo/prebuild-config": ^55.0.16
-    "@react-native/metro-config": ~0.82.0
+    "@react-native/metro-config": ~0.82.1
     "@types/react": ~19.1.0
     expo: ^55.0.17
     react: 19.1.1
@@ -43,7 +44,7 @@ catalogs:
     "@expo/config-plugins": ^55.0.8
     "@expo/config-types": ^55.0.5
     "@expo/prebuild-config": ^55.0.16
-    "@react-native/metro-config": ~0.83.0
+    "@react-native/metro-config": ~0.83.10
     "@types/react": ~19.2.0
     expo: ^55.0.17
     react: 19.2.0

--- a/scripts/custom-changeset/src/changeset-add.test.ts
+++ b/scripts/custom-changeset/src/changeset-add.test.ts
@@ -1,9 +1,13 @@
 import type { Package, Packages } from "@manypkg/tools";
 
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import test from "node:test";
 
-import { createChangeset } from "./changeset-add.ts";
+import { createChangeset, getChangedPackagesSinceRef } from "./changeset-add.ts";
 import { disambiguatePackages } from "./package-identities.ts";
 
 function packageAt(
@@ -94,4 +98,55 @@ test("rejects packages that name@version still cannot distinguish", () => {
       ),
     /each one must have a different version/,
   );
+});
+
+test("detects changes in the assembled package list, including injected templates", async (t) => {
+  const rootDir = await fs.mkdtemp(path.join(tmpdir(), "expo-desktop-changeset-add-test-"));
+  t.after(() => fs.rm(rootDir, { recursive: true, force: true }));
+
+  const workspaceDir = path.join(rootDir, "packages/workspace");
+  const template54Dir = path.join(rootDir, "templates/bare/54.81");
+  const template55Dir = path.join(rootDir, "templates/bare/55.82");
+  const packageDirs = [workspaceDir, template54Dir, template55Dir];
+  await Promise.all(packageDirs.map((dir) => fs.mkdir(path.join(dir, "src"), { recursive: true })));
+  await Promise.all(
+    packageDirs.map((dir) => fs.writeFile(path.join(dir, "src/index.js"), "initial\n")),
+  );
+
+  execFileSync("git", ["init", "-b", "main"], { cwd: rootDir, stdio: "ignore" });
+  execFileSync("git", ["add", "."], { cwd: rootDir, stdio: "ignore" });
+  execFileSync(
+    "git",
+    [
+      "-c",
+      "user.name=Changeset Test",
+      "-c",
+      "user.email=changeset-test@example.com",
+      "commit",
+      "-m",
+      "Initial commit",
+    ],
+    { cwd: rootDir, stdio: "ignore" },
+  );
+
+  await fs.writeFile(path.join(workspaceDir, "src/index.js"), "changed\n");
+  await fs.writeFile(path.join(template54Dir, "src/index.js"), "changed\n");
+
+  const result = disambiguatePackages(
+    packages(
+      packageAt(workspaceDir, "workspace", "1.0.0"),
+      packageAt(template54Dir, "template", "54.81.0"),
+      packageAt(template55Dir, "template", "55.82.0"),
+    ),
+  );
+  const changedPackages = await getChangedPackagesSinceRef(result.packages.packages, {
+    cwd: rootDir,
+    ref: "main",
+    changedFilePatterns: ["src/**"],
+  });
+
+  assert.deepEqual(changedPackages.map(({ packageJson }) => packageJson.name).toSorted(), [
+    "template@54.81.0",
+    "workspace",
+  ]);
 });

--- a/scripts/custom-changeset/src/changeset-add.ts
+++ b/scripts/custom-changeset/src/changeset-add.ts
@@ -32,9 +32,10 @@ import fs from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+// FORK (start 3)
+import picomatch from "picomatch";
 import semverLt from "semver/functions/lt.js";
 
-// FORK (start 3)
 import { disambiguatePackages } from "./package-identities.ts";
 // FORK (end 3)
 
@@ -59,21 +60,6 @@ const {
 } = await import(new URL("./dist/src.mjs", cliPackageJsonUrl).href);
 type Color = Extract<Parameters<typeof import("node:util").styleText>[0], string>;
 type ColorProxy = Record<Color, (text: string) => string>;
-
-const {
-  t: getVersionableChangedPackages,
-}: {
-  t(
-    config: Config,
-    {
-      cwd,
-      ref,
-    }: {
-      cwd: string;
-      ref?: string;
-    },
-  ): Promise<Array<Package>>;
-} = await import(new URL("./dist/versionablePackages.mjs", cliPackageJsonUrl).href);
 
 const {
   t: getCommitFunctions,
@@ -108,6 +94,65 @@ type QuestionOptions = {
 };
 type MultiselectOptions<Value> = Record<string, Option<Value>[]>;
 
+// FORK (start 4)
+/**
+ * This is getChangedPackagesSinceRef() from @changesets/git, except that the
+ * caller supplies the package list. Our templates are intentionally not
+ * workspaces, so letting the upstream function rediscover packages would omit
+ * them from change detection.
+ */
+export async function getChangedPackagesSinceRef(
+  packages: ReadonlyArray<Package>,
+  {
+    cwd,
+    ref,
+    changedFilePatterns = ["**"],
+  }: {
+    cwd: string;
+    ref: string;
+    changedFilePatterns?: Config["changedFilePatterns"];
+  },
+): Promise<Array<Package>> {
+  const changedFiles = await git.getChangedFilesSince({ cwd, ref, fullPath: true });
+
+  // Assign files to the most deeply nested package, matching Changesets'
+  // behavior for repositories that contain nested packages.
+  return packages
+    .toSorted((pkgA, pkgB) => pkgB.dir.length - pkgA.dir.length)
+    .filter((pkg) => {
+      const changedPackageFiles = new Array<string>();
+      for (let i = changedFiles.length - 1; i >= 0; i--) {
+        const relativeFile = path.relative(pkg.dir, changedFiles[i]);
+        if (
+          relativeFile === "" ||
+          relativeFile === ".." ||
+          relativeFile.startsWith(`..${path.sep}`) ||
+          path.isAbsolute(relativeFile)
+        )
+          continue;
+
+        changedFiles.splice(i, 1);
+        changedPackageFiles.push(relativeFile);
+      }
+      return globMatchSome(changedPackageFiles, changedFilePatterns);
+    });
+}
+
+function globMatchSome(paths: Array<string>, patterns: Config["changedFilePatterns"]): boolean {
+  if (!patterns) return paths.length > 0;
+  const matchers = patterns.map((pattern) => picomatch(pattern, undefined, true));
+  return paths.some((filePath) => {
+    const normalizedPath = filePath.replace(/\\/g, "/");
+    let passed = false;
+    for (const matcher of matchers)
+      if (!passed) {
+        if (!matcher.state.negated && matcher(normalizedPath)) passed = true;
+      } else if (matcher.state.negated && !matcher(normalizedPath)) passed = false;
+    return passed;
+  });
+}
+// FORK (end 4)
+
 export async function add(options: {
   /**
    * Support specifying extra packages beyond the ones picked up by
@@ -137,7 +182,7 @@ export async function add(options: {
   // Changesets uses package names as map keys everywhere, including while it
   // validates the dependency graph. Give duplicate template lines a virtual,
   // version-qualified name before any Changesets code sees them.
-  const { packageNamesByDir, packages, patchOnlyPackageNames } = disambiguatePackages(
+  const { packages, patchOnlyPackageNames } = disambiguatePackages(
     discoveredPackages,
     new Set(options.extraPackages?.map(({ dir }) => path.resolve(dir))),
   );
@@ -177,17 +222,15 @@ export async function add(options: {
   else {
     let changedPackagesNames = new Array<string>();
     try {
+      // FORK (start 6)
       changedPackagesNames = (
-        await getVersionableChangedPackages(config, {
+        await getChangedPackagesSinceRef(versionablePackages, {
           cwd: packages.rootDir,
-          ref: options?.since,
+          ref: options?.since ?? config.baseBranch,
+          changedFilePatterns: config.changedFilePatterns,
         })
-      ).map(
-        (pkg) =>
-          // FORK (start 6)
-          packageNamesByDir.get(path.resolve(pkg.dir)) ?? pkg.packageJson.name,
-        // FORK (end 6)
-      );
+      ).map((pkg) => pkg.packageJson.name);
+      // FORK (end 6)
     } catch (error) {
       log.warn(
         `

--- a/templates/bare-minimum/54.81/CHANGELOG.md
+++ b/templates/bare-minimum/54.81/CHANGELOG.md
@@ -1,5 +1,11 @@
 # expo-desktop-template-bare-minimum
 
+## 54.81.1-beta.5
+
+### Patch Changes
+
+- Use expo-desktop-metro-config instead of unmaintained metro.config.js
+
 ## 54.81.1-beta.4
 
 ### Patch Changes

--- a/templates/bare-minimum/54.81/metro.config.js
+++ b/templates/bare-minimum/54.81/metro.config.js
@@ -1,6 +1,3 @@
-const { getDefaultConfig } = require("@expo/metro-config");
-const { makeMetroConfig } = require("@rnx-kit/metro-config");
+const { makeMetroConfig } = require("expo-desktop-metro-config");
 
-const config = makeMetroConfig(getDefaultConfig(__dirname));
-config.resolver.platforms = ["ios", "android", "macos", "windows", "web"];
-module.exports = config;
+module.exports = makeMetroConfig(__dirname);

--- a/templates/bare-minimum/54.81/package.json
+++ b/templates/bare-minimum/54.81/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-desktop-template-bare-minimum",
-  "version": "54.81.1-beta.4",
+  "version": "54.81.1-beta.5",
   "description": "This bare project template includes a minimal setup for using unimodules with React Native.",
   "license": "0BSD",
   "repository": {
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@react-native-community/cli": "^20.1.3",
     "@types/react": "~19.2.17",
-    "expo-desktop-metro-config": "~54.81.0-beta.1",
+    "expo-desktop-metro-config": "~54.81.0-beta.2",
     "typescript": "~5.9.2"
   },
   "overrides": {

--- a/templates/bare-minimum/54.81/package.json
+++ b/templates/bare-minimum/54.81/package.json
@@ -31,9 +31,8 @@
   },
   "devDependencies": {
     "@react-native-community/cli": "^20.1.3",
-    "@react-native/metro-config": "0.81.6",
-    "@rnx-kit/metro-config": "^2.2.4",
     "@types/react": "~19.2.17",
+    "expo-desktop-metro-config": "~54.81.0-beta.1",
     "typescript": "~5.9.2"
   },
   "overrides": {

--- a/templates/blank-typescript/54.81/CHANGELOG.md
+++ b/templates/blank-typescript/54.81/CHANGELOG.md
@@ -1,5 +1,11 @@
 # expo-desktop-template-blank-typescript
 
+## 54.81.1-beta.5
+
+### Patch Changes
+
+- Use expo-desktop-metro-config instead of unmaintained metro.config.js
+
 ## 54.81.1-beta.4
 
 ### Patch Changes

--- a/templates/blank-typescript/54.81/metro.config.js
+++ b/templates/blank-typescript/54.81/metro.config.js
@@ -1,6 +1,3 @@
-const { getDefaultConfig } = require("@expo/metro-config");
-const { makeMetroConfig } = require("@rnx-kit/metro-config");
+const { makeMetroConfig } = require("expo-desktop-metro-config");
 
-const config = makeMetroConfig(getDefaultConfig(__dirname));
-config.resolver.platforms = ["ios", "android", "macos", "windows", "web"];
-module.exports = config;
+module.exports = makeMetroConfig(__dirname);

--- a/templates/blank-typescript/54.81/package.json
+++ b/templates/blank-typescript/54.81/package.json
@@ -30,9 +30,8 @@
   },
   "devDependencies": {
     "@react-native-community/cli": "^20.1.3",
-    "@react-native/metro-config": "0.81.6",
-    "@rnx-kit/metro-config": "^2.2.4",
     "@types/react": "~19.2.17",
+    "expo-desktop-metro-config": "~54.81.0-beta.1",
     "expo-desktop-template-bare-minimum": "~54.81.1-beta.4",
     "typescript": "~5.9.2"
   },

--- a/templates/blank-typescript/54.81/package.json
+++ b/templates/blank-typescript/54.81/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-desktop-template-blank-typescript",
-  "version": "54.81.1-beta.4",
+  "version": "54.81.1-beta.5",
   "description": "An Expo Desktop template for React Native v0.81, based on Expo SDK 54",
   "repository": {
     "type": "git",
@@ -31,8 +31,8 @@
   "devDependencies": {
     "@react-native-community/cli": "^20.1.3",
     "@types/react": "~19.2.17",
-    "expo-desktop-metro-config": "~54.81.0-beta.1",
-    "expo-desktop-template-bare-minimum": "~54.81.1-beta.4",
+    "expo-desktop-metro-config": "~54.81.0-beta.2",
+    "expo-desktop-template-bare-minimum": "~54.81.1-beta.5",
     "typescript": "~5.9.2"
   },
   "overrides": {


### PR DESCRIPTION
This will allow me to easily migrate users from `@react-native/metro-config` + `@rnx-kit/metro-config` in Expo SDK 54, to `@expo/metro-config` in Expo SDK 57 (and maybe Expo SDK 56, if it gets backported), which incorporates https://github.com/expo/expo/pull/46344.