### PR TITLE
deps: bump toml to 4.3.0 in expo-desktop (GHSA-82x6-q7mm-w9cf, GHSA-v5mp-jgw5-2x6j)

### DIFF
--- a/packages/expo-desktop/package.json
+++ b/packages/expo-desktop/package.json
@@ -64,7 +64,7 @@
     "prompts": "^2.4.2",
     "resolve-from": "^5.0.0",
     "semver": "^7.6.0",
-    "toml": "^4.1.1"
+    "toml": "^4.2.0"
   },
   "devDependencies": {
     "@octokit/types": "^13.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,8 +204,8 @@ importers:
         specifier: ^7.6.0
         version: 7.7.4
       toml:
-        specifier: ^4.1.1
-        version: 4.1.1
+        specifier: ^4.2.0
+        version: 4.3.0
     devDependencies:
       '@octokit/types':
         specifier: ^13.5.0
@@ -4635,8 +4635,8 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
-  toml@4.1.1:
-    resolution: {integrity: sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw==}
+  toml@4.3.0:
+    resolution: {integrity: sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A==}
     engines: {node: '>=20'}
 
   ts-interface-checker@0.1.13:
@@ -10355,7 +10355,7 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
-  toml@4.1.1: {}
+  toml@4.3.0: {}
 
   ts-interface-checker@0.1.13: {}
 


### PR DESCRIPTION
Updates `toml` to address GHSA-82x6-q7mm-w9cf and GHSA-v5mp-jgw5-2x6j.

Evidence:
- `pnpm-lock.yaml` resolved `toml@4.1.1`
- osv-scanner reported GHSA-82x6-q7mm-w9cf (uncontrolled recursion) and GHSA-v5mp-jgw5-2x6j (prototype pollution) on `toml@4.1.1`
- updated version: `4.3.0` (specifier `^4.2.0`)

Validation:
- osv-scanner no longer reports either advisory for `toml` after the update
- `pnpm --filter expo-desktop test` (vitest run): 3 passed, 1 failed. The failing test (`template-versions.test.ts` "fetches template versions from npm") fails identically on main before this change, so it is pre-existing and unrelated to this bump.

Scope: dependency update in `packages/expo-desktop/package.json` and `pnpm-lock.yaml` only.

Note: osv-scanner still reports advisories for other packages in `pnpm-lock.yaml` (for example `@xmldom/xmldom@0.7.13`, `@babel/core@7.29.0`). This patch only clears the two `toml` advisories.
